### PR TITLE
Set rw and idle timeouts

### DIFF
--- a/main.go
+++ b/main.go
@@ -67,12 +67,14 @@ func main() {
 	http.Handle("/", r)
 
 	srv := &http.Server{
-		Handler:      loggingHandler,
-		Addr:         "0.0.0.0:8443",
-		TLSConfig:    tlsConf,
-		TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0),
-		WriteTimeout: 15 * time.Second,
-		ReadTimeout:  15 * time.Second,
+		Handler:           loggingHandler,
+		Addr:              "0.0.0.0:8443",
+		TLSConfig:         tlsConf,
+		TLSNextProto:      make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0),
+		WriteTimeout:      30 * time.Second,
+		ReadTimeout:       20 * time.Second,
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       60 * time.Second,
 	}
 
 	log.Fatal(srv.ListenAndServeTLS("certs/regcred-injector-crt.pem", "certs/regcred-injector-key.pem"))


### PR DESCRIPTION
Set read/write timeouts in line with usage of TLS, meaning write
deadlines are set during TLS handshake. Set the write deadline
to that of the admission controll request timeout default of 30s

Set an idle timeout for keep alive connections