### PR TITLE
Fix secret creation when pod created via deployment

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -20,4 +20,4 @@ version: 0.1.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.1.21
+appVersion: 0.1.30

--- a/chart/templates/admission-configuration.yaml
+++ b/chart/templates/admission-configuration.yaml
@@ -12,9 +12,9 @@ webhooks:
       values: ["regcred-injector"]
   rules:
   - operations: ["CREATE"]
-    apiGroups: [""]
-    apiVersions: ["v1"]
-    resources: ["pods"]
+    apiGroups: ["*"]
+    apiVersions: ["*"]
+    resources: ["pods", "deployments", "statefulset", "replicaset", "daemonset"]
     scope: "Namespaced"
   clientConfig:
     service:


### PR DESCRIPTION
When a deployment triggers pod creation, the admissionreview
request does not appear to have a fully formed Pod for its Object
field.
Updated the admission logic to respond to the creation of
deployments, statefulsets, replicasets and daemonsets, creating
the secret in the target namespace when one is encountered.
As a corollory to this, restricted the mutation logic to add
imagePullSecrets to Pod kinds exclusively