### PR TITLE
Fix resource names in admission controller config

### DIFF
--- a/chart/templates/admission-configuration.yaml
+++ b/chart/templates/admission-configuration.yaml
@@ -14,7 +14,7 @@ webhooks:
   - operations: ["CREATE"]
     apiGroups: ["*"]
     apiVersions: ["*"]
-    resources: ["pods", "deployments", "statefulset", "replicaset", "daemonset"]
+    resources: ["pods", "deployments", "statefulsets", "replicasets", "daemonsets"]
     scope: "Namespaced"
   clientConfig:
     service:


### PR DESCRIPTION
Made the resources plural, in line with pods and deployments