### PR TITLE
Revert to pod-only strategy

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -20,4 +20,4 @@ version: 0.1.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.1.32
+appVersion: 0.1.34

--- a/chart/templates/admission-configuration.yaml
+++ b/chart/templates/admission-configuration.yaml
@@ -12,9 +12,9 @@ webhooks:
       values: ["regcred-injector"]
   rules:
   - operations: ["CREATE"]
-    apiGroups: ["*"]
-    apiVersions: ["*"]
-    resources: ["pods", "deployments", "statefulsets", "replicasets", "daemonsets"]
+    apiGroups: [""]
+    apiVersions: ["v1"]
+    resources: ["pods"]
     scope: "Namespaced"
   clientConfig:
     service:


### PR DESCRIPTION
An earlier change to install credentials based on deployments (& co)
was not needed as the target namespace is available in the admission
review object.