### PR TITLE
Warn when secret creation fails

### DIFF
--- a/handlers/admission.go
+++ b/handlers/admission.go
@@ -135,8 +135,7 @@ func PodHandler(w http.ResponseWriter, r *http.Request) {
 
 	err = createSecret(namespace, req.Request.UID)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+		log.Printf("%s failed to create secret, continuing to mutate: %s", req.Request.UID, err.Error())
 	}
 
 	var responseReview *admission.AdmissionReview


### PR DESCRIPTION
If secret creation in a namespace fails we fail the http request.
This now warns, but otherwise continues.

This caters for the case where secret creation fails because the
secret has been created already, but an additional retry mechanism
should be added to cater for other transient issues with credential
creation