### PR TITLE
Allow target registry override

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ Installation into a Kubernetes cluster is possible with helm. Required parameter
 
 `helm install --set docker.username=<username>  --set docker.password=<PAT> --set-file cert=certs/regcred-injector-crt.pem --set-file key=certs/regcred-injector-key.pem my-release chart`
 
+Installation with a Scaleway private registry.
+
+`helm install --set docker.username=<accesskey>  --set docker.password=<secretkey> --set docker.registry=rg.fr-par.scw.cloud --set-file cert=certs/regcred-injector-crt.pem --set-file key=certs/regcred-injector-key.pem my-release chart`
+
+
 ## Cert generation
 
 TODO: Add information on how to generate self-signed certs

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # regcred-injector
 
 regcred-injector is a Kubernetes admission controller which allows you to
-globally set a set of Dockerhub registry credentials.
+globally set a registry credential.
 
 This is achieved by hooking into pod creation and mutating the pod with
 an `imagePullSecrets` entry. This is currently limited to adding a single
-`imagePullSecret`. 
+`imagePullSecret`.
 
 Along with mutating the pod, credentials will be created in the target namespace,
 provided they don't already exist.
@@ -27,8 +27,7 @@ will receive the registry secrets as pods are created.
 
 ## Usage
 
-Installation into a Kubernetes cluster is possible with helm. Required parameters are the docker username and password (PAT), as well as a self-signed TLS keypair which Kubernetes
-uses to authenticate with the deployed service.
+Installation into a Kubernetes cluster is possible with helm. Required parameters are the docker username and password (PAT), as well as a self-signed TLS keypair which Kubernetes uses to authenticate with the deployed service.
 
 `helm install --set docker.username=<username>  --set docker.password=<PAT> --set-file cert=certs/regcred-injector-crt.pem --set-file key=certs/regcred-injector-key.pem my-release chart`
 

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -20,4 +20,4 @@ version: 0.1.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.1.35
+appVersion: 0.1.37

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -47,6 +47,8 @@ spec:
               value: {{ include "regcred-injector.fullname" . }}.{{ .Release.Namespace }}.svc.local
             - name: DOCKER_USERNAME
               value: {{ .Values.docker.username }}
+            - name: DOCKER_REGISTRY
+              value: "{{ .Values.docker.registry }}"
             - name: DOCKER_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -10,6 +10,13 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+docker:
+  registry: "https://index.docker.io/v1/"
+  password: ""
+
+cert: ""
+key: ""
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/handlers/admission.go
+++ b/handlers/admission.go
@@ -19,6 +19,7 @@ import (
 var Clientset *kubernetes.Clientset
 var DockerUsername string
 var DockerPassword string
+var DockerRegistry string
 
 func getReview(r *http.Request) (admission.AdmissionReview, error) {
 	var rev admission.AdmissionReview
@@ -57,7 +58,7 @@ func createSecret(namespace string, uid types.UID) error {
 		dockerAuth.Username = DockerUsername
 		dockerAuth.Password = DockerPassword
 		dockerAuth.Auth = base64.StdEncoding.EncodeToString([]byte(DockerUsername + ":" + DockerPassword))
-		dockerConfig.Auths["https://index.docker.io/v1/"] = dockerAuth
+		dockerConfig.Auths[DockerRegistry] = dockerAuth
 
 		dockerConfigJSON, err := json.Marshal(dockerConfig)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -44,6 +44,10 @@ func main() {
 	if !found {
 		log.Fatal("Unable to read DOCKER_PASSWORD environment variable")
 	}
+	handlers.DockerRegistry, found = os.LookupEnv("DOCKER_REGISTRY")
+	if !found {
+		log.Fatal("Unable to read DOCKER_REGISTRY environment variable")
+	}
 
 	log.SetOutput(os.Stdout)
 


### PR DESCRIPTION
Allow overriding the target registry via `docker.registry`
The default remains the dockerhub registry

Resolves #26