### PR TITLE
Don't overwrite existing imagePullSecrets

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -20,4 +20,4 @@ version: 0.1.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.1.37
+appVersion: 0.1.39

--- a/k8s/utils.go
+++ b/k8s/utils.go
@@ -1,9 +1,15 @@
 package k8s
 
-type RegCredPatchSpec struct {
+type CreatePatchSpec struct {
 	Op    string              `json:"op"`
 	Path  string              `json:"path"`
 	Value []map[string]string `json:"value"`
+}
+
+type AppendPatchSpec struct {
+	Op    string            `json:"op"`
+	Path  string            `json:"path"`
+	Value map[string]string `json:"value"`
 }
 
 type DockerAuth struct {


### PR DESCRIPTION
When there are existing imagePullSecrets, return a JSONPatch which
appends the new secret, rather than overwriting in its entirety

Resolves #34