### PR TITLE
feat: always update regcred secret with latest values

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.1.41-beta2
+appVersion: 0.1.41

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -20,4 +20,4 @@ version: 0.2.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.1.40
+appVersion: 0.1.41-beta2

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -20,7 +20,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["get", "list", "create"]  
+  verbs: ["get", "list", "create", "update"]  
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 # This role binding allows "jane" to read pods in the "default" namespace.

--- a/handlers/admission.go
+++ b/handlers/admission.go
@@ -37,15 +37,6 @@ func hasImagePullSecrets(pod apiv1.Pod) bool {
 	return len(pod.Spec.ImagePullSecrets) > 0
 }
 
-func jsonEscape(i string) string {
-	b, err := json.Marshal(i)
-	if err != nil {
-		panic(err)
-	}
-	s := string(b)
-	return s[1 : len(s)-1]
-}
-
 func createSecret(namespace string, uid types.UID) error {
 	secrets, err := Clientset.CoreV1().Secrets(namespace).List(context.TODO(), v1.ListOptions{})
 	if err != nil {


### PR DESCRIPTION
If the regcred secret exists in a namespace, update it with the
latest values. This avoids having to delete old secrets when
cycling the docker secrets

Implements #6, #7