### PR TITLE
Update MutatingWebhookConfiguration apiVersion

### DIFF
--- a/chart/templates/admission-configuration.yaml
+++ b/chart/templates/admission-configuration.yaml
@@ -1,7 +1,7 @@
 {{- $certString := include "regcred-injector.gen-certs" . -}}
 {{- $certList := split "$" $certString -}}
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
     name:  {{ include "regcred-injector.fullname" . }}


### PR DESCRIPTION
`v1` appeared in k8s `v1.16`
`v1beta1` gets deprecated in k8s `v1.22`